### PR TITLE
Use RedisConfig::default_clustered() in cluster intergration tests

### DIFF
--- a/tests/integration/cluster.rs
+++ b/tests/integration/cluster.rs
@@ -188,7 +188,7 @@ pub mod lists {
 
   #[test]
   fn it_should_llen_on_empty_list() {
-    let config = RedisConfig::default();
+    let config = RedisConfig::default_clustered();
     utils::setup_test_client(config, |client| {
       lists_tests::should_llen_on_empty_list(client)
     });
@@ -196,7 +196,7 @@ pub mod lists {
 
   #[test]
   fn it_should_llen_on_list_with_elements() {
-    let config = RedisConfig::default();
+    let config = RedisConfig::default_clustered();
     utils::setup_test_client(config, |client| {
       lists_tests::should_llen_on_list_with_elements(client)
     });
@@ -204,7 +204,7 @@ pub mod lists {
 
   #[test]
   fn it_should_lpush_and_lpop_to_list() {
-    let config = RedisConfig::default();
+    let config = RedisConfig::default_clustered();
     utils::setup_test_client(config, |client| {
       lists_tests::should_lpush_and_lpop_to_list(client)
     });


### PR DESCRIPTION
Used the wrong configuration in my tests. Should this line also change? https://github.com/azuqua/fred.rs/blob/master/tests/integration/cluster.rs#L177