### PR TITLE
[OKTA-349376] test: put sadd in mocks

### DIFF
--- a/src/mocks/utils.rs
+++ b/src/mocks/utils.rs
@@ -161,6 +161,7 @@ pub fn handle_command(inner: &Arc<RedisClientInner>, data_ref: &Arc<RwLock<DataS
       RedisCommandKind::Ping     => commands::ping(data, command.args),
       RedisCommandKind::Info     => commands::info(data, command.args),
       RedisCommandKind::Persist  => commands::persist(data, command.args),
+      RedisCommandKind::Sadd     => commands::sadd(data, command.args),
       RedisCommandKind::Smembers => commands::smembers(data, command.args),
       RedisCommandKind::Publish  => commands::publish(data, command.args),
       RedisCommandKind::Subscribe => commands::subscribe(data, command.args),


### PR DESCRIPTION
## Description

- Put `sadd` in the mocks

If you run the tests suite with mocks flipped on, the sadd test will now pass where it didn't before. Also verified locally with the engine.

## Testing Details

- [x] Verified basic functionality of change
- [ ] Added tests
- [x] Followed [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)

### Resolves

- [OKTA-349376](https://oktainc.atlassian.net/browse/OKTA-349376)

## Primary Reviewer(s)

- @azuqua/core-team 