### PR TITLE
[OKTA-361505] feat!: inclusive language and upgrade to redis 5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "1.3.2"
+version = "2.0.0"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."

--- a/src/client.rs
+++ b/src/client.rs
@@ -313,7 +313,7 @@ impl RedisClient {
     utils::is_clustered(&self.inner.config)
   }
 
-  /// Split a clustered redis client into a list of centralized clients for each master node in the cluster.
+  /// Split a clustered redis client into a list of centralized clients for each primary node in the cluster.
   ///
   /// This is an expensive operation and should not be used frequently.
   pub fn split_cluster(&self, handle: &Handle) -> Box<Future<Item=Vec<(RedisClient, RedisConfig)>, Error=RedisError>> {

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -214,7 +214,7 @@ pub enum RedisCommandKind {
   ClusterSaveConfig,
   ClusterSetConfigEpoch,
   ClusterSetSlot,
-  ClusterSlaves,
+  ClusterReplicas,
   ClusterSlots,
   ConfigGet,
   ConfigRewrite,
@@ -323,7 +323,7 @@ pub enum RedisCommandKind {
   Sinter,
   Sinterstore,
   Sismember,
-  Slaveof,
+  Replicaof,
   Slowlog,
   Smembers,
   Smove,
@@ -543,7 +543,7 @@ impl RedisCommandKind {
       RedisCommandKind::ClusterSaveConfig               => "CLUSTER",
       RedisCommandKind::ClusterSetConfigEpoch           => "CLUSTER",
       RedisCommandKind::ClusterSetSlot                  => "CLUSTER",
-      RedisCommandKind::ClusterSlaves                   => "CLUSTER",
+      RedisCommandKind::ClusterReplicas                 => "CLUSTER",
       RedisCommandKind::ClusterSlots                    => "CLUSTER",
       RedisCommandKind::ConfigGet                       => "CONFIG",
       RedisCommandKind::ConfigRewrite                   => "CONFIG",
@@ -652,7 +652,7 @@ impl RedisCommandKind {
       RedisCommandKind::Sinter                          => "SINTER",
       RedisCommandKind::Sinterstore                     => "SINTERSTORE",
       RedisCommandKind::Sismember                       => "SISMEMBER",
-      RedisCommandKind::Slaveof                         => "SLAVEOF",
+      RedisCommandKind::Replicaof                       => "REPLICAOF",
       RedisCommandKind::Slowlog                         => "SLOWLOG",
       RedisCommandKind::Smembers                        => "SMEMBERS",
       RedisCommandKind::Smove                           => "SMOVE",
@@ -741,7 +741,7 @@ impl RedisCommandKind {
       RedisCommandKind::ClusterSaveConfig               => "CLUSTER",
       RedisCommandKind::ClusterSetConfigEpoch           => "CLUSTER",
       RedisCommandKind::ClusterSetSlot                  => "CLUSTER",
-      RedisCommandKind::ClusterSlaves                   => "CLUSTER",
+      RedisCommandKind::ClusterReplicas                 => "CLUSTER",
       RedisCommandKind::ClusterSlots                    => "CLUSTER",
       RedisCommandKind::ConfigGet                       => "CONFIG",
       RedisCommandKind::ConfigRewrite                   => "CONFIG",
@@ -850,7 +850,7 @@ impl RedisCommandKind {
       RedisCommandKind::Sinter                          => "SINTER",
       RedisCommandKind::Sinterstore                     => "SINTERSTORE",
       RedisCommandKind::Sismember                       => "SISMEMBER",
-      RedisCommandKind::Slaveof                         => "SLAVEOF",
+      RedisCommandKind::Replicaof                       => "REPLICAOF",
       RedisCommandKind::Slowlog                         => "SLOWLOG",
       RedisCommandKind::Smembers                        => "SMEMBERS",
       RedisCommandKind::Smove                           => "SMOVE",
@@ -922,7 +922,7 @@ impl RedisCommandKind {
       | RedisCommandKind::ClusterSaveConfig
       | RedisCommandKind::ClusterSetConfigEpoch
       | RedisCommandKind::ClusterSetSlot
-      | RedisCommandKind::ClusterSlaves
+      | RedisCommandKind::ClusterReplicas
       | RedisCommandKind::ClusterSlots                 => true,
       _ => false
     }
@@ -946,7 +946,7 @@ impl RedisCommandKind {
       RedisCommandKind::ClusterSaveConfig               => "SAVECONFIG",
       RedisCommandKind::ClusterSetConfigEpoch           => "SET-CONFIG-EPOCH",
       RedisCommandKind::ClusterSetSlot                  => "SETSLOT",
-      RedisCommandKind::ClusterSlaves                   => "SLAVES",
+      RedisCommandKind::ClusterReplicas                 => "REPLICAS",
       RedisCommandKind::ClusterSlots                    => "SLOTS",
       _ => return None
     };
@@ -1014,7 +1014,7 @@ impl RedisCommandKind {
   pub fn is_read(&self) -> bool {
     use RedisCommandKind::*;
 
-    // TODO finish this and use for sending reads to slaves
+    // TODO finish this and use for sending reads to replicas
     match *self {
       _ => false
     }
@@ -1122,15 +1122,15 @@ impl RedisCommand {
 
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SlaveNodes {
+pub struct ReplicaNodes {
   servers: Vec<String>,
   next: usize
 }
 
-impl SlaveNodes {
+impl ReplicaNodes {
 
-  pub fn new(servers: Vec<String>) -> SlaveNodes {
-    SlaveNodes {
+  pub fn new(servers: Vec<String>) -> ReplicaNodes {
+    ReplicaNodes {
       servers,
       next: 0
     }
@@ -1164,8 +1164,8 @@ pub struct SlotRange {
   pub server: String,
   pub id: String,
   // TODO
-  // cache slaves for each master and round-robin reads to the slaves + master, and only send writes to the master
-  pub slaves: Option<SlaveNodes>
+  // cache replicas for each primary and round-robin reads to the replicas + primary, and only send writes to the primary
+  pub replicas: Option<ReplicaNodes>
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR updates fred to use the inclusive language alternatives available as of Redis 5.0, both on the client API and the underlying redis commands being wrapped:
`slave` -> `replica`
`primary` -> `master`

Note that I marked this a breaking change, since it is not backwards compatible; we have removed the non-inclusive commands altogether instead of leaving them in under their old names. 