### PR TITLE
[OKTA-385823] chore: support hash tags in scan command patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."

--- a/src/multiplexer/mod.rs
+++ b/src/multiplexer/mod.rs
@@ -173,6 +173,10 @@ impl Multiplexer {
     }else{
       None
     };
+    let key_slot = match request.kind {
+      RedisCommandKind::Scan(ref s) => s.key_slot.clone(),
+      _ => None
+    };
 
     let frame = match request.to_frame() {
       Ok(f) => f,
@@ -182,7 +186,7 @@ impl Multiplexer {
     if request.kind == RedisCommandKind::Quit {
       self.sinks.quit(frame)
     }else{
-      self.sinks.write_command(key, frame, no_cluster)
+      self.sinks.write_command(key, frame, no_cluster, key_slot)
     }
   }
 

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -90,6 +90,7 @@ impl PartialEq for ResponseKind {
 impl Eq for ResponseKind {}
 
 pub struct KeyScanInner {
+  pub key_slot: Option<u16>,
   pub cursor: String,
   pub tx: UnboundedSender<Result<ScanResult, RedisError>>
 }


### PR DESCRIPTION
* Support hash tags in scan patterns so that callers can pick the node to scan when used against a cluster.

If a scan pattern hash tag contains a wildcard this will warn the user that they're probably not scanning the correct node.