### PR TITLE
[OKTA-403451] fix: support special slot entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -54,6 +54,7 @@ use futures::sync::mpsc::UnboundedSender;
 use std::collections::{VecDeque, HashMap};
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::cmp::Ordering;
 
 #[derive(Clone)]
 pub enum ResponseKind {
@@ -1167,6 +1168,18 @@ pub struct SlotRange {
   // TODO
   // cache replicas for each primary and round-robin reads to the replicas + primary, and only send writes to the primary
   pub replicas: Option<ReplicaNodes>
+}
+
+impl PartialOrd for SlotRange {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Ord for SlotRange {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.start.cmp(&other.start)
+  }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Supports special hash slot migration hash slots in the CLUSTER NODES response.

Fixes:
* https://oktainc.atlassian.net/browse/OKTA-403451