### PR TITLE
[OKTA-407560] fix: stop underflowing on empty clusters

### DIFF
--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -51,8 +51,13 @@ pub fn binary_search(slots: &Vec<Arc<SlotRange>>, slot: u16) -> Option<Arc<SlotR
   if slot > REDIS_CLUSTER_SLOTS {
     return None;
   }
-
-  let (mut low, mut high) = (0, slots.len() - 1);
+  
+  let mut low = 0;
+  // an empty vec will cause underflow if we do `slots.len() - 1` and subsequent panic, so stop early
+  let mut high = match usize::checked_sub(slots.len(), 1) {
+    Some(h) => h,
+    None => return None
+  };
 
   while low <= high {
     let mid = (low + high) / 2;


### PR DESCRIPTION
There is an intermittent panic in fred for binary searching for the server to use. It kills the engine, which makes engines stop processing jobs. (explained below in comments)

Created 3 tests for this behavior; one that actually panics and one each from the `CLUSTER NODES` output from fl10 and azq-prod, although this was obtained several hours (days for fl10) after this happened and neither of these actually panic before the fix. 