### PR TITLE
[OKTA-411559] chore: refactor memory usage command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1033,7 +1033,7 @@ pub fn memoryusage<K: Into<RedisKey>>(inner: &Arc<RedisClientInner>, key: K, sam
   let key = key.into();
 
   Box::new(utils::request_response(inner, move || {
-    let mut args = vec!["USAGE".into(), key.into()];
+    let mut args = vec![key.into()];
     if let Some(num_samples) = samples {
       let mut samples_vec = vec!["SAMPLES".into(), num_samples.into()];
       args.append(&mut samples_vec);

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -1007,6 +1007,22 @@ impl RedisCommandKind {
     Some(s.to_owned())
   }
 
+  pub fn is_memory_command(&self) -> bool {
+    match *self {
+      RedisCommandKind::MemoryUsage => true,
+      _ => false
+    }
+  }
+
+  pub fn memory_args(&self) -> Option<String> {
+    let s = match *self {
+      RedisCommandKind::MemoryUsage => "USAGE",
+      _ => return None
+    };
+
+    Some(s.to_owned())
+  }
+
   pub fn is_blocking(&self) -> bool {
     match *self {
       RedisCommandKind::BlPop(_)

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -244,6 +244,12 @@ pub fn command_args(kind: &RedisCommandKind) -> Option<ProtocolFrame> {
     }else{
       return None;
     }
+  }else if kind.is_memory_command() {
+    if let Some(arg) = kind.memory_args() {
+      ProtocolFrame::BulkString(arg.into_bytes())
+    }else{
+      return None;
+    }
   }else{
     return None;
   };


### PR DESCRIPTION
Change memory usage command to use subcommand part like other commands (e.g. config).

Ran the centralized tests locally against redis docker to verify that the tests I added last time still pass. 

* [OKTA-411559](https://oktainc.atlassian.net/browse/OKTA-411559)