### PR TITLE
[OKTA-413156] fix: take memory usage out of mocks so they compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."

--- a/src/mocks/utils.rs
+++ b/src/mocks/utils.rs
@@ -162,7 +162,6 @@ pub fn handle_command(inner: &Arc<RedisClientInner>, data_ref: &Arc<RwLock<DataS
       RedisCommandKind::Info        => commands::info(data, command.args),
       RedisCommandKind::Persist     => commands::persist(data, command.args),
       RedisCommandKind::Sadd        => commands::sadd(data, command.args),
-      RedisCommandKind::MemoryUsage => commands::memoryusage(data, command.args),
       RedisCommandKind::Smembers    => commands::smembers(data, command.args),
       RedisCommandKind::Publish     => commands::publish(data, command.args),
       RedisCommandKind::Subscribe   => commands::subscribe(data, command.args),


### PR DESCRIPTION
When adding the memory usage command, my find/replace went a little too far and compiling with the `mocks` feature stopped working. This change fixes it, as confirmed by `cargo check --features mocks` which failed before this commit and passes with this commit. 

(The engine requires the mocks feature for its tests.)