### PR TITLE
chore: increment patch version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."


### PR DESCRIPTION
Increment the patch version for 2.1.2 release