### PR TITLE
[OKTA-558567] fix vulnerable dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-timer-patched = "0.1.3"
 tokio-core = "0.1.17"
 tokio-proto = "0.1.1"
 tokio-io = "0.1.12"
-rand = "0.3"
+rand = "0.8.5"
 
 [dev-dependencies]
 hyper = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."
@@ -32,6 +32,10 @@ tokio-core = "0.1.17"
 tokio-proto = "0.1.1"
 tokio-io = "0.1.12"
 rand = "0.8.5"
+
+# https://oktainc.atlassian.net/browse/OKTA-558567
+# manually patch smallvec dependency
+smallvec = "=1.10.0"
 
 [dev-dependencies]
 hyper = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 futures = "0.1"
-parking_lot = "0.7.0"
+parking_lot = "0.12.1"
 lazy_static = "1.3.0"
 bytes = "0.4.11"
 redis-protocol = "0.1.2"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,6 +58,7 @@ use std::sync::atomic::{
   Ordering,
   AtomicUsize
 };
+use rand::distributions::Alphanumeric;
 
 use crate::multiplexer::utils as multiplexer_utils;
 use crate::protocol::utils as protocol_utils;
@@ -334,8 +335,9 @@ pub fn split(inner: &Arc<RedisClientInner>, handle: &Handle, timeout: u64) -> Bo
 
 pub fn random_string(len: usize) -> String {
   rand::thread_rng()
-    .gen_ascii_chars()
+    .sample_iter(Alphanumeric)
     .take(len)
+    .map(char::from)
     .collect()
 }
 


### PR DESCRIPTION
* `parking-lot` 0.7.0 -> 0.12.1
* `rand` 0.3 -> 0.8.5
* `tokio-proto -> smallvec` 0.2.1 -> 1.10.0

Part of OKTA-558567