### PR TITLE
fix: revert pinning smallvec to 1.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,6 @@ tokio-proto = "0.1.1"
 tokio-io = "0.1.12"
 rand = "0.8.5"
 
-# https://oktainc.atlassian.net/browse/OKTA-558567
-# manually patch smallvec dependency
-smallvec = "=1.10.0"
-
 [dev-dependencies]
 hyper = "0.11"
 


### PR DESCRIPTION
Tried to manually patch `smallvec` to a non-vulnerable version but this causes upstream dependencies to be unable to resolve a version not equal to 1.10.0 

Regardless I don't think cargo is able to resolve the _ancient_ version of `smallvec` used by `tokio-proto` anyways. We'll need to accept the risk for this vuln until we're ready to move to fred 5/6.