### PR TITLE
feat: add LTRIM command

### DIFF
--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -139,6 +139,8 @@ pub trait RedisClientBorrowed {
 
   fn lpop<K: Into<RedisKey>>(&self, key: K) -> Box<Future<Item=Option<RedisValue>, Error=RedisError>>;
 
+  fn ltrim<K: Into<RedisKey>>(&self, key: K, start: i64, stop: i64) -> Box<Future<Item=String, Error=RedisError>>;
+
   fn memoryusage<K: Into<RedisKey>>(&self, key: K, samples: Option<i64>) -> Box<Future<Item=usize, Error=RedisError>>;
 
   fn sadd<K: Into<RedisKey>, V: Into<MultipleValues>>(&self, key: K, values: V) -> Box<Future<Item=usize, Error=RedisError>>;
@@ -594,6 +596,17 @@ impl RedisClientBorrowed for RedisClient {
   /// <https://redis.io/commands/lpop>
   fn lpop<K: Into<RedisKey>>(&self, key: K) -> Box<Future<Item=Option<RedisValue>, Error=RedisError>> {
     commands::lpop(&self.inner, key)
+  }
+
+  /// Trim an existing list so that it will contain only the specified range of elements specified.
+  /// Both `start` and `stop` are zero-based indexes, where 0 is the first element of the list (the
+  /// head), 1 the next element and so on.
+  /// 
+  /// Returns a simple string acknowledgement.
+  /// 
+  /// <https://redis.io/commands/ltrim/>
+  fn ltrim<K: Into<RedisKey>>(&self, key: K, start: i64, stop: i64) -> Box<Future<Item=String, Error=RedisError>> {
+    commands::ltrim(&self.inner, key, start, stop)
   }
 
   /// Report the number of bytes that a key and its value require to be stored in RAM.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1029,6 +1029,25 @@ pub fn lpop<K: Into<RedisKey>>(inner: &Arc<RedisClientInner>, key: K) -> Box<Fut
   }))
 }
 
+pub fn ltrim<K: Into<RedisKey>>(inner: &Arc<RedisClientInner>, key: K, start: i64, stop: i64) -> Box<Future<Item=String, Error=RedisError>> {
+  let key = key.into();
+
+  Box::new(utils::request_response(inner, move || {
+    let args = vec![key.into(), start.into(), stop.into()];
+
+    Ok((RedisCommandKind::LTrim, args))
+  }).and_then(|frame| {
+    let resp = protocol_utils::frame_to_single_result(frame)?;
+
+    match resp {
+      RedisValue::String(resp) => Ok(resp),
+      _ => Err(RedisError::new(
+        RedisErrorKind::Unknown , "Invalid LTRIM response."
+      ))
+    }
+  }))
+}
+
 pub fn memoryusage<K: Into<RedisKey>>(inner: &Arc<RedisClientInner>, key: K, samples: Option<i64>) -> Box<Future<Item=usize, Error=RedisError>> {
   let key = key.into();
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -136,6 +136,8 @@ pub trait RedisClientOwned: Sized {
 
   fn lpop<K: Into<RedisKey>>(self, key: K) -> Box<Future<Item=(Self, Option<RedisValue>), Error=RedisError>>;
 
+  fn ltrim<K: Into<RedisKey>>(self, key: K, start: i64, stop: i64) -> Box<Future<Item=(Self, String), Error=RedisError>>;
+  
   fn memoryusage<K: Into<RedisKey>>(&self, key: K, samples: Option<i64>) -> Box<Future<Item=usize, Error=RedisError>>;
 
   fn sadd<K: Into<RedisKey>, V: Into<MultipleValues>>(self, key: K, values: V) -> Box<Future<Item=(Self, usize), Error=RedisError>>;
@@ -590,6 +592,17 @@ impl RedisClientOwned for RedisClient {
   /// <https://redis.io/commands/lpop>
   fn lpop<K: Into<RedisKey>>(self, key: K) -> Box<Future<Item=(Self, Option<RedisValue>), Error=RedisError>> {
     run_borrowed(self, |inner| commands::lpop(inner, key))
+  }
+
+  /// Trim an existing list so that it will contain only the specified range of elements specified.
+  /// Both `start` and `stop` are zero-based indexes, where 0 is the first element of the list (the
+  /// head), 1 the next element and so on.
+  /// 
+  /// Returns a simple string acknowledgement.
+  /// 
+  /// <https://redis.io/commands/ltrim/>
+  fn ltrim<K: Into<RedisKey>>(self, key: K, start: i64, stop: i64) -> Box<Future<Item=(Self, String), Error=RedisError>> {
+    run_borrowed(self, |inner| commands::ltrim(inner, key, start, stop))
   }
 
   /// Report the number of bytes that a key and its value require to be stored in RAM.

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -220,6 +220,14 @@ pub mod lists {
       lists_tests::should_lpush_and_lpop_to_list(client)
     });
   }
+
+  #[test]
+  fn it_should_ltrim_list() {
+    let config = RedisConfig::default();
+    utils::setup_test_client(config, TIMER.clone(),|client| {
+      lists_tests::should_ltrim_list(client)
+    });
+  }
 }
 
 pub mod sets {

--- a/tests/integration/cluster.rs
+++ b/tests/integration/cluster.rs
@@ -217,6 +217,14 @@ pub mod lists {
       lists_tests::should_lpush_and_lpop_to_list(client)
     });
   }
+
+  #[test]
+  fn it_should_ltrim_list() {
+    let config = RedisConfig::default_clustered();
+    utils::setup_test_client(config, TIMER.clone(),|client| {
+      lists_tests::should_ltrim_list(client)
+    });
+  }
 }
 
 pub mod sets {

--- a/tests/integration/utils.rs
+++ b/tests/integration/utils.rs
@@ -1,6 +1,7 @@
 
 use fred;
 
+use rand::distributions::Alphanumeric;
 use tokio_core::reactor::{
   Handle,
   Core,
@@ -158,7 +159,8 @@ pub fn setup_two_test_clients<F: FnOnce(RedisClient, RedisClient) -> TestFuture>
 
 pub fn random_string(len: usize) -> String {
   rand::thread_rng()
-    .gen_ascii_chars()
+    .sample_iter(Alphanumeric)
     .take(len)
+    .map(char::from)
     .collect()
 }


### PR DESCRIPTION
Added the LTRIM command (which will replace LPOP usage in another project to maintain a maximum queue length) with a test.