### PR TITLE
[OKTA-619863] refactor: replace azuqua github references with atko-flow github references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2018"
 description = "A Redis client for Rust built on Futures and Tokio."
 readme = "README.md"
-repository = "https://github.com/azuqua/fred.rs"
-homepage = "https://github.com/azuqua/fred.rs"
+repository = "https://github.com/atko-flow/fred.rs"
+homepage = "https://github.com/atko-flow/fred.rs"
 keywords = ["redis", "futures", "async", "cluster", "tokio"]
 license = "MIT"
 
 [badges]
-travis-ci = { repository = "azuqua/fred.rs", branch = "master" }
+travis-ci = { repository = "atko-flow/fred.rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Fred
 ====
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Build Status](https://travis-ci.org/azuqua/fred.rs.svg?branch=master)](https://travis-ci.org/azuqua/fred.rs)
 [![Crates.io](https://img.shields.io/crates/v/fred.svg)](https://crates.io/crates/fred)
 [![API docs](https://docs.rs/fred/badge.svg)](https://docs.rs/fred)
 
@@ -101,7 +100,7 @@ fn main() {
 }
 ```
 
-See [examples](https://github.com/azuqua/fred.rs/tree/master/examples) for more.
+See [examples](https://github.com/atko-flow/fred.rs/tree/master/examples) for more.
 
 ## Redis Cluster
 


### PR DESCRIPTION
replace azuqua github references with atko-flow github references

### Resolves

- [OKTA-619863](https://oktainc.atlassian.net/browse/OKTA-619863)